### PR TITLE
Clarify upload timeframes

### DIFF
--- a/lib/accepted.html
+++ b/lib/accepted.html
@@ -26,11 +26,12 @@ file sizes to make sure the file was uploaded correctly.</p>
 
 {filenames}
 
-<p>Note that your files may not appear in the
+<p>Note that your files will not appear in the
 <a href="/if-archive/unprocessed/">unprocessed</a>
-folder immediately, and they may not be moved to their final
-destination for a few days after that. For more information
-on the upload process,
+folder immediately. A human moderator will usually move your files
+to the "unprocessed" folder within a few days, and then move
+unprocessed files to their final destination a few days after that.
+For more information on the upload process,
 <a href="/misc/uploader-docs.html">see this post</a>.</p>
 
 <p>Thanks again for your upload. You may 


### PR DESCRIPTION
* The most important change is to clarify that uploaded files absolutely will not appear in the `unprocessed` folder immediately. (The existing text says that "your files may not appear in the `unprocessed` folder immediately," as if there's a  chance that they _might_ be there immediately.)
* The new text indicates that moving to `unprocessed` might take days (hopefully 24 hours, but, let's give ourselves some leeway) and that moving to the final destination will take days after that.