### PR TITLE
Include a link to the admintool in emails to webuploader

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -412,6 +412,9 @@ problem persists, please contact the archive maintainers.</p>""")
         msg.append("IFDB ID: %s\n" % (ifdbID,))
         # Try writing the IFDB ID to a text file
     msg.append('\n\n')
+
+    msg.append('https://upload.ifarchive.org/admin/incoming')
+    msg.append('\n\n')
     
     msg = ''.join(msg)
     fnamesForMailing = ' '.join(fnamesForMailing)


### PR DESCRIPTION
That way, when I get an email to webuploader, I can just click the link in the email to process the file.